### PR TITLE
New release with workflows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+# Pull Request Template
+
+## Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please check only the options that are relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+
+**Test Configuration**:
+
+* OS (please include version):
+* Any other relevant environment information:
+
+## Checklist:
+
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have checked my code and corrected any misspellings
+

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,19 @@
+name: Push new tag update to stable branch
+
+on:
+  schedule:
+    # Daily for now
+    - cron: '9 7 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-snapcraft-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v3
+      - name: Run desktop-snaps action  
+        uses: ubuntu/desktop-snaps@stable
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: build-test
+on:
+  pull_request:
+  push:
+    branches:
+      - edge
+      - stable
+
+jobs:
+  snap:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: snapcore/action-build@v1
+      id: snapcraft
+    - uses: actions/upload-artifact@v2
+      with:
+        name: 'snap'
+        path: ${{ steps.snapcraft.outputs.snap}}

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -30,10 +30,12 @@ apps:
 
 parts:
   gnome-weather:
+# ext:updatesnap
     after: [geoclue]
     source: https://gitlab.gnome.org/GNOME/gnome-weather.git
     source-type: git
-    source-branch: gnome-42
+    source-tag: '44.0'
+    source-depth: 1
     plugin: meson
     meson-parameters: [--buildtype=release, --prefix=/snap/gnome-weather/current/usr]
     build-packages: [meson, ninja-build]
@@ -54,9 +56,10 @@ parts:
     prime:
       - -usr/share/gnome-shell/search-providers
   geoclue:
+# ext:updatesnap
     source: https://gitlab.freedesktop.org/geoclue/geoclue.git
     source-type: git
-    source-branch: 2.6.x
+    source-tag: '2.7.0'
     plugin: meson
     meson-parameters: [--prefix=/usr, -Dgtk-doc=false, -D3g-source=false, -Dcdma-source=false, -Dmodem-gps-source=false, -Dnmea-source=false, -Ddemo-agent=false]
     prime:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -60,6 +60,7 @@ parts:
     source: https://gitlab.freedesktop.org/geoclue/geoclue.git
     source-type: git
     source-tag: '2.7.0'
+    source-depth: 1
     plugin: meson
     meson-parameters: [--prefix=/usr, -Dgtk-doc=false, -D3g-source=false, -Dcdma-source=false, -Dmodem-gps-source=false, -Dnmea-source=false, -Ddemo-agent=false]
     prime:


### PR DESCRIPTION
This PR updates the version of both parts and tracks tags instead of branches. Both the tracking tags and source-depth is a requirement for the auto-update.yml. The auto-update.yml will use [the action that automates tag updates](https://github.com/ubuntu/desktop-snaps/blob/stable/action.yml).

While I was at it, I added the build.yml that will launch a build any time there is a new commit on the main branch.

I also added a PR template.